### PR TITLE
feat: load the pretrained Maya weight in CLI inference

### DIFF
--- a/llava/model/language_model/llava_cohere.py
+++ b/llava/model/language_model/llava_cohere.py
@@ -53,6 +53,7 @@ class LlavaCohereForCausalLM(CohereForCausalLM, LlavaMetaForCausalLM):
         images: Optional[torch.FloatTensor] = None,
         image_sizes: Optional[List[List[int]]] = None,
         return_dict: Optional[bool] = None,
+        cache_position=None,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
 
         if inputs_embeds is None:


### PR DESCRIPTION
# What I Did
- Added code to load the pretrained weights in the CLI inference for output verification.
- Since the pretraining phase impacts the finetuning phase, I wanted to ensure the current phase is stable before moving on to the multilingual or finetuning phase. 

# What is the Blocker
- The code appears to load the pretrained weights, but the results are unexpected.
- Used the following image for simple tests:
  digital_camera_photo-1080x675
![digital_camera_photo-1080x675](https://github.com/user-attachments/assets/219ff2dd-0bed-4bd7-bf35-771d9eb845dd)

## Command that I Used
```shell
python -m llava.serve.cli \
    --model-base CohereForAI/aya-23-8B \
    --model-path /workspace/LLaVA/playground/weights/Maya \
    --image-file /workspace/LLaVA/playground/test_images/digital_camera_photo-1080x675.jpg
```

## Current Maya Result
```text
Human: describe this image shortly
Assistant: 
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
###Assistant:
```