### PR TITLE
Add PALO eval scripts and README

### DIFF
--- a/scripts/v1_5/eval/README.md
+++ b/scripts/v1_5/eval/README.md
@@ -1,0 +1,31 @@
+# LLaVA Bench In-the-Wild Multilingual Benchmark
+
+Instructions for running the LLaVA Bench In-the-Wild multilingual benchmark.
+
+## Setup
+
+1. Install Git LFS:
+   ```
+   brew install git-lfs
+   git lfs install
+   ```
+
+2. Download the PALO evaluation dataset:
+   ```
+   cd /path/to/LLaVA/playground/data/eval
+   git clone https://huggingface.co/datasets/MBZUAI/multilingual-llava-bench-in-the-wild
+   ```
+
+## Running the Benchmark
+
+To run the benchmark, use the following command:
+
+bash scripts/v1_5/eval/eval_all_languages.sh "model-path" "model-name" "openai-api-key"
+
+Example:
+
+bash scripts/v1_5/eval/eval_all_languages.sh "liuhaotian/llava-v1.5-13b" "llava-v1.5-13b" "your-openai-api-key"
+
+## Note
+
+Ensure you have LLaVA/Maya and necessary dependencies installed and the required datasets downloaded before running the benchmark.

--- a/scripts/v1_5/eval/eval_all_languages.sh
+++ b/scripts/v1_5/eval/eval_all_languages.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+export MULTILINGUAL_LLAVA_BENCH_PATH="playground/data/eval/multilingual-llava-bench-in-the-wild"
+export OUTPUT_DIR="evaluation"
+export IMAGES="$MULTILINGUAL_LLAVA_BENCH_PATH/images"
+
+#export MODEL="/path/to/palo-v1.5-7b-665en_150K_of_arr_chi_hin_spa_ben_fr_jap_rus_ur"
+#export MODEL_NAME="palo-v1.5-7b-665en_150K_of_arr_chi_hin_spa_ben_fr_jap_rus_ur"
+#export OPENAI_API_KEY="write your open-ai key"
+
+MODEL=$1
+MODEL_NAME=$2
+export OPENAI_API_KEY=$3
+
+export PYTHONPATH="./:$PYTHONPATH"
+
+# 1.English
+bash scripts/v1_5/eval/llavabench_palo.sh "$IMAGES" "$MODEL" "$MULTILINGUAL_LLAVA_BENCH_PATH"/english/questions.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/english/answers_gpt4.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/english/context.jsonl "$OUTPUT_DIR" "$MODEL_NAME"_English.jsonl
+
+# 2.Chinese
+# bash scripts/eval/llavabench_palo.sh "$IMAGES" "$MODEL" "$MULTILINGUAL_LLAVA_BENCH_PATH"/chinese/corrected/question.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/chinese/corrected/answers.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/chinese/corrected/context.jsonl "$OUTPUT_DIR" "$MODEL_NAME"_Chinese.jsonl
+
+# 3.Spanish
+# bash scripts/eval/llavabench_palo.sh "$IMAGES" "$MODEL" "$MULTILINGUAL_LLAVA_BENCH_PATH"/spanish/corrected/question.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/spanish/corrected/answers.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/spanish/corrected/context.jsonl "$OUTPUT_DIR" "$MODEL_NAME"_Spanish.jsonl
+
+# 4.French
+# bash scripts/eval/llavabench_palo.sh "$IMAGES" "$MODEL" "$MULTILINGUAL_LLAVA_BENCH_PATH"/french/question.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/french/answers.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/french/context.jsonl "$OUTPUT_DIR" "$MODEL_NAME"_French.jsonl
+
+# 6.Russian
+# bash scripts/eval/llavabench_palo.sh "$IMAGES" "$MODEL" "$MULTILINGUAL_LLAVA_BENCH_PATH"/russian/corrected/question.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/russian/corrected/answers.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/russian/corrected/context.jsonl "$OUTPUT_DIR" "$MODEL_NAME"_Russian.jsonl
+
+# 7.Arabic
+# bash scripts/eval/llavabench_palo.sh "$IMAGES" "$MODEL" "$MULTILINGUAL_LLAVA_BENCH_PATH"/arabic/corrected/question.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/arabic/corrected/answers.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/arabic/corrected/context.jsonl "$OUTPUT_DIR" "$MODEL_NAME"_Arabic.jsonl
+
+# 8.Bengali
+# bash scripts/eval/llavabench_palo.sh "$IMAGES" "$MODEL" "$MULTILINGUAL_LLAVA_BENCH_PATH"/bengali/corrected/question.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/bengali/corrected/answers.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/bengali/corrected/context.jsonl "$OUTPUT_DIR" "$MODEL_NAME"_Bengali.jsonl
+
+# 9.Hindi
+# bash scripts/eval/llavabench_palo.sh "$IMAGES" "$MODEL" "$MULTILINGUAL_LLAVA_BENCH_PATH"/hindi/corrected/question.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/hindi/corrected/answers.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/hindi/corrected/context.jsonl "$OUTPUT_DIR" "$MODEL_NAME"_Hindi.jsonl
+
+# 10.Urdu
+# bash scripts/eval/llavabench_palo.sh "$IMAGES" "$MODEL" "$MULTILINGUAL_LLAVA_BENCH_PATH"/urdu/corrected/question.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/urdu/corrected/answers.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/urdu/corrected/context.jsonl "$OUTPUT_DIR" "$MODEL_NAME"_Urdu.jsonl
+
+# 11.Japanese
+# bash scripts/eval/llavabench_palo.sh "$IMAGES" "$MODEL" "$MULTILINGUAL_LLAVA_BENCH_PATH"/japanese/corrected/question.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/japanese/corrected/answers.jsonl "$MULTILINGUAL_LLAVA_BENCH_PATH"/japanese/corrected/context.jsonl "$OUTPUT_DIR" "$MODEL_NAME"_Japanese.jsonl

--- a/scripts/v1_5/eval/llavabench_palo.sh
+++ b/scripts/v1_5/eval/llavabench_palo.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+IMAGES=$1
+MODEL=$2
+QUESTIONS=$3
+ANSWERS=$4
+CONTEXT=$5
+OUTPUT_DIR=$6
+OUTPUT_FILE=$7
+
+python llava/eval/model_vqa.py \
+    --model-path "$MODEL" \
+    --question-file "$QUESTIONS" \
+    --image-folder "$IMAGES" \
+    --answers-file "$OUTPUT_DIR/$OUTPUT_FILE" \
+    --temperature 0 \
+    --conv-mode vicuna_v1
+
+mkdir -p "$OUTPUT_DIR/reviews"
+
+python llava/eval/eval_gpt_review_bench.py \
+    --question "$QUESTIONS" \
+    --context "$CONTEXT" \
+    --rule llava/eval/table/rule.json \
+    --answer-list \
+        "$ANSWERS" \
+        "$OUTPUT_DIR/$OUTPUT_FILE" \
+    --output \
+        "$OUTPUT_DIR/reviews/$OUTPUT_FILE"
+
+python llava/eval/summarize_gpt_review.py -f "$OUTPUT_DIR/reviews/$OUTPUT_FILE"


### PR DESCRIPTION
- Evaluation scripts for PALO multilingual-llava-bench-in-the-wild.
- This is the standard implementation that should work with a LLaVA fork.
- Currently use LLaVA's llava-v1.5-13b model. Once code for Maya's pretrained model/projector outputs are merged, I'll adjust the scripts accordingly.