### PR TITLE
Eval for VizWiz

### DIFF
--- a/llava/eval/model_vqa_vizwiz.py
+++ b/llava/eval/model_vqa_vizwiz.py
@@ -1,0 +1,210 @@
+import argparse
+import torch
+import os
+import json
+from tqdm import tqdm
+import shortuuid
+
+from llava.constants import (
+    IMAGE_TOKEN_INDEX,
+    DEFAULT_IMAGE_TOKEN,
+    DEFAULT_IM_START_TOKEN,
+    DEFAULT_IM_END_TOKEN,
+)
+from llava.conversation import conv_templates, SeparatorStyle
+from llava.model.builder import load_pretrained_model
+from llava.utils import disable_torch_init
+from llava.mm_utils import (
+    tokenizer_image_token,
+    process_images,
+    get_model_name_from_path,
+)
+from llava.eval.maya.eval_utils import load_maya_model
+from torch.utils.data import Dataset, DataLoader
+
+from PIL import Image
+import math
+
+
+def split_list(lst, n):
+    """Split a list into n (roughly) equal-sized chunks"""
+    chunk_size = math.ceil(len(lst) / n)  # integer division
+    return [lst[i : i + chunk_size] for i in range(0, len(lst), chunk_size)]
+
+
+def get_chunk(lst, n, k):
+    chunks = split_list(lst, n)
+    return chunks[k]
+
+
+# Custom dataset class
+class CustomDataset(Dataset):
+    def __init__(
+        self, questions, image_folder, tokenizer, image_processor, model_config
+    ):
+        self.questions = questions
+        self.image_folder = image_folder
+        self.tokenizer = tokenizer
+        self.image_processor = image_processor
+        self.model_config = model_config
+
+    def __getitem__(self, index):
+        line = self.questions[index]
+        image_file = line["image"]
+        qs = line["question"]
+        if self.model_config.mm_use_im_start_end:
+            qs = (
+                DEFAULT_IM_START_TOKEN
+                + DEFAULT_IMAGE_TOKEN
+                + DEFAULT_IM_END_TOKEN
+                + "\n"
+                + qs
+            )
+        else:
+            qs = DEFAULT_IMAGE_TOKEN + "\n" + qs
+
+        conv = conv_templates[args.conv_mode].copy()
+        conv.append_message(conv.roles[0], qs)
+        conv.append_message(conv.roles[1], None)
+        prompt = conv.get_prompt()
+
+        image = Image.open(os.path.join(self.image_folder, image_file)).convert("RGB")
+        image_tensor = process_images([image], self.image_processor, self.model_config)[
+            0
+        ]
+
+        input_ids = tokenizer_image_token(
+            prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt"
+        )
+
+        return input_ids, image_tensor, image.size
+
+    def __len__(self):
+        return len(self.questions)
+
+
+def collate_fn(batch):
+    input_ids, image_tensors, image_sizes = zip(*batch)
+    input_ids = torch.stack(input_ids, dim=0)
+    image_tensors = torch.stack(image_tensors, dim=0)
+    return input_ids, image_tensors, image_sizes
+
+
+# DataLoader
+def create_data_loader(
+    questions,
+    image_folder,
+    tokenizer,
+    image_processor,
+    model_config,
+    batch_size=1,
+    num_workers=4,
+):
+    assert batch_size == 1, "batch_size must be 1"
+    dataset = CustomDataset(
+        questions, image_folder, tokenizer, image_processor, model_config
+    )
+    data_loader = DataLoader(
+        dataset,
+        batch_size=batch_size,
+        num_workers=num_workers,
+        shuffle=False,
+        collate_fn=collate_fn,
+    )
+    return data_loader
+
+
+def eval_model(args):
+    # Model
+    disable_torch_init()
+    model_path = os.path.expanduser(args.model_path)
+    model_name = get_model_name_from_path(model_path)
+    
+    if 'maya' not in model_name:
+        tokenizer, model, image_processor, context_len = load_pretrained_model(model_path, args.model_base, model_name)
+    else:
+        model, tokenizer, image_processor, context_len = load_maya_model(args.model_base, model_path, mode=args.mode)
+
+    # Open the question file with utf-8-sig to handle potential BOM issues
+    question_file_path = os.path.expanduser(args.question_file)
+
+    # Debugging to print the content of the file and any parsing issues
+    try:
+        with open(question_file_path, "r", encoding="utf-8-sig") as f:
+            # Load the entire file as a single JSON array
+            questions = json.load(f)
+
+        # Split questions based on chunks
+        questions = get_chunk(questions, args.num_chunks, args.chunk_idx)
+
+    except json.JSONDecodeError as e:
+        print(f"JSONDecodeError while reading the question file: {e}")
+        return  # Exit if there are critical file issues
+    except Exception as e:
+        print(f"Failed to read or parse the question file: {e}")
+        return
+
+    # Setup the answers file
+    answers_file = os.path.expanduser(args.answers_file)
+    os.makedirs(os.path.dirname(answers_file), exist_ok=True)
+    ans_file = open(answers_file, "w")
+
+    if 'plain' in model_name and 'finetune' not in model_name.lower() and 'mmtag' not in args.conv_mode:
+        args.conv_mode = args.conv_mode + '_mmtag'
+        print(f'It seems that this is a plain model, but it is not using an mmtag prompt, auto switching to {args.conv_mode}.')
+
+    # Create the data loader
+    data_loader = create_data_loader(questions, args.image_folder, tokenizer, image_processor, model.config)
+
+    # Loop through the data loader and generate answers
+    for (input_ids, image_tensor, image_sizes), line in tqdm(zip(data_loader, questions), total=len(questions)):
+        idx = line["question"]
+        cur_prompt = line["question"]
+
+        input_ids = input_ids.to(device='cuda', non_blocking=True)
+
+        with torch.inference_mode():
+            output_ids = model.generate(
+                input_ids,
+                images=image_tensor.to(dtype=torch.float16, device='cuda', non_blocking=True),
+                image_sizes=image_sizes,
+                do_sample=True if args.temperature > 0 else False,
+                temperature=args.temperature,
+                top_p=args.top_p,
+                num_beams=args.num_beams,
+                max_new_tokens=args.max_new_tokens,
+                use_cache=True)
+
+        outputs = tokenizer.batch_decode(output_ids, skip_special_tokens=True)[0].strip()
+
+        ans_id = shortuuid.uuid()
+        ans_file.write(json.dumps({"question_id": idx,
+                                   "prompt": cur_prompt,
+                                   "text": outputs,
+                                   "answer_id": ans_id,
+                                   "model_id": model_name,
+                                   "metadata": {}}) + "\n")
+        # ans_file.flush()
+    
+    ans_file.close()
+
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-path", type=str, default="nahidalam/maya_full_ft")
+    parser.add_argument("--model-base", type=str, default="CohereForAI/aya-23-8B")
+    parser.add_argument("--mode", type=str, default="finetuned")
+    parser.add_argument("--image-folder", type=str, default="")
+    parser.add_argument("--question-file", type=str, default="tables/question.jsonl")
+    parser.add_argument("--answers-file", type=str, default="answer.jsonl")
+    parser.add_argument("--conv-mode", type=str, default="llava_v1")
+    parser.add_argument("--num-chunks", type=int, default=1)
+    parser.add_argument("--chunk-idx", type=int, default=0)
+    parser.add_argument("--temperature", type=float, default=0.2)
+    parser.add_argument("--top_p", type=float, default=None)
+    parser.add_argument("--num_beams", type=int, default=1)
+    parser.add_argument("--max_new_tokens", type=int, default=128)
+    args = parser.parse_args()
+
+    eval_model(args)

--- a/scripts/maya/eval/vizwiz.sh
+++ b/scripts/maya/eval/vizwiz.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-python -m llava.eval.model_vqa_loader \
+python -m llava.eval.model_vqa_vizwiz \
     --model-path nahidalam/maya_full_ft \
     --model-base CohereForAI/aya-23-8B \
-    --question-file ./playground/data/eval/vizwiz/test.json \
-    --image-folder ./playground/data/eval/vizwiz/test \
-    --answers-file ./playground/data/eval/vizwiz/answers/llava-v1.5-13b.jsonl \
+    --question-file ../../../playground/data/eval/vizwiz/test.json \
+    --image-folder ../../../playground/data/eval/vizwiz/test \
+    --answers-file ../../../playground/data/eval/vizwiz/answers/llava-v1.5-13b.jsonl \
     --temperature 0 \
     --conv-mode aya
+
 
 python scripts/convert_vizwiz_for_submission.py \
     --annotation-file ./playground/data/eval/vizwiz/test.json \


### PR DESCRIPTION
Support for VizWiz eval.

Fixes a problem where `model_vqa_loader` fails to load VizWiz's `test.json`. This is a decoder error because the dataset is a json array enclosed in square brackets `[]` which is not recognised by the decoder.

A new `model_vqa_vizwiz` script was created to fix this issue.

