### PR TITLE
Fix vizwiz eval

### DIFF
--- a/docs/Evaluation.md
+++ b/docs/Evaluation.md
@@ -57,7 +57,7 @@ CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 bash scripts/v1_5/eval/vqav2.sh
 CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 bash scripts/v1_5/eval/gqa.sh
 ```
 
-### VisWiz
+### VizWiz
 
 1. Download [`test.json`](https://vizwiz.cs.colorado.edu/VizWiz_final/vqa_data/Annotations.zip) and extract [`test.zip`](https://vizwiz.cs.colorado.edu/VizWiz_final/images/test.zip) to `test`. Put them under `./playground/data/eval/vizwiz`. You may ingore any vizwiz files (jsonl) from the LLaVA zip file.
 2. Single-GPU inference.

--- a/docs/Evaluation.md
+++ b/docs/Evaluation.md
@@ -59,10 +59,10 @@ CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 bash scripts/v1_5/eval/gqa.sh
 
 ### VisWiz
 
-1. Download [`test.json`](https://vizwiz.cs.colorado.edu/VizWiz_final/vqa_data/Annotations.zip) and extract [`test.zip`](https://vizwiz.cs.colorado.edu/VizWiz_final/images/test.zip) to `test`. Put them under `./playground/data/eval/vizwiz`.
+1. Download [`test.json`](https://vizwiz.cs.colorado.edu/VizWiz_final/vqa_data/Annotations.zip) and extract [`test.zip`](https://vizwiz.cs.colorado.edu/VizWiz_final/images/test.zip) to `test`. Put them under `./playground/data/eval/vizwiz`. You may ingore any vizwiz files (jsonl) from the LLaVA zip file.
 2. Single-GPU inference.
 ```Shell
-CUDA_VISIBLE_DEVICES=0 bash scripts/v1_5/eval/vizwiz.sh
+CUDA_VISIBLE_DEVICES=0 bash scripts/maya/eval/vizwiz.sh
 ```
 3. Submit the results to the [evaluation server](https://eval.ai/web/challenges/challenge-page/2185/my-submission): `./playground/data/eval/vizwiz/answers_upload`.
 

--- a/scripts/maya/eval/vizwiz.sh
+++ b/scripts/maya/eval/vizwiz.sh
@@ -3,14 +3,23 @@
 python -m llava.eval.model_vqa_vizwiz \
     --model-path nahidalam/maya_full_ft \
     --model-base CohereForAI/aya-23-8B \
-    --question-file ../../../playground/data/eval/vizwiz/test.json \
-    --image-folder ../../../playground/data/eval/vizwiz/test \
-    --answers-file ../../../playground/data/eval/vizwiz/answers/llava-v1.5-13b.jsonl \
+    --question-file ./playground/data/eval/vizwiz/test.json \
+    --image-folder ./playground/data/eval/vizwiz/test \
+    --answers-file ./playground/data/eval/vizwiz/answers/maya_test.jsonl \
     --temperature 0 \
     --conv-mode aya
+
+# python -m llava.eval.model_vqa_loader \
+#     --model-path nahidalam/maya_full_ft \
+#     --model-base CohereForAI/aya-23-8B \
+#     --question-file ./playground/data/eval/vizwiz/llava_test_short.jsonl \
+#     --image-folder  ./playground/data/eval/vizwiz/test \
+#     --answers-file  ./playground/data/eval/vizwiz/answers/maya.jsonl \
+#     --temperature 0 \
+#     --conv-mode aya
 
 
 python scripts/convert_vizwiz_for_submission.py \
     --annotation-file ./playground/data/eval/vizwiz/test.json \
-    --result-file ./playground/data/eval/vizwiz/answers/llava-v1.5-13b.jsonl \
+    --result-file ./playground/data/eval/vizwiz/answers/maya_test.jsonl \
     --result-upload-file ./playground/data/eval/vizwiz/answers_upload/maya_full_ft.json


### PR DESCRIPTION
- Swap from using LLaVA's provided questions jsonl file to using the original vizwiz json file
- Updated submission code to work with json files instead of jsonl
- Custom prompting to `llava/eval/model_vqa_vizwiz.py` (this was added by LLaVA devs in their jsonl file, but we use the original vizwiz questions + LLaVA custom prompt injected inside `vqa_vizwiz.py`)
- Updated eval.ai challenge link