### PR TITLE
Update train.py to support 2D ROPE

### DIFF
--- a/llava/train/train.py
+++ b/llava/train/train.py
@@ -66,6 +66,8 @@ class ModelArguments:
     freeze_backbone: bool = field(default=False)
     tune_mm_mlp_adapter: bool = field(default=False)
     vision_tower: Optional[str] = field(default=None)
+    use_vision_rope_2d: Optional[bool] = field(default=False)
+    rope_theta: Optional[float] = field(default=10000.0)
     mm_vision_select_layer: Optional[int] = field(default=-1)   # default to the last layer
     pretrain_mm_mlp_adapter: Optional[str] = field(default=None)
     mm_projector_type: Optional[str] = field(default='linear')


### PR DESCRIPTION
1. Added the parameters for 2d rope in train.py (use_vision_rope_2d and rope_theta)
2. README and pyproject.toml are already updated with working versions as of mine.